### PR TITLE
Enable building on other machines.

### DIFF
--- a/CoreMIDI4J/Build/Project Builder.xml
+++ b/CoreMIDI4J/Build/Project Builder.xml
@@ -1,4 +1,4 @@
-<project name="CoreMIDI4J Project Builder" basedir="/Development/CoreMIDI4J/bin">
+<project name="CoreMIDI4J Project Builder" basedir="../bin">
 	<!-- edit the following lines to your needs -->
 	<target name="Initialise">
 		<echo> "Setting Properties" </echo>
@@ -15,9 +15,9 @@
 
 	<target name="MakeJar">
 		<echo> "Creating Jar File" </echo>
-		<delete file="/Development/CoreMIDI4J/Build/Release/CoreMIDI4J.jar"/>
-		<jar destfile="/Development/CoreMIDI4J/Build/Release/CoreMIDI4J.jar" 
-			basedir="/Development/CoreMIDI4J/bin">
+		<delete file="../Build/Release/CoreMIDI4J.jar"/>
+		<jar destfile="../Build/Release/CoreMIDI4J.jar"
+			basedir="../bin">
 			<service type="javax.sound.midi.spi.MidiDeviceProvider" provider="com.xfactoryLibrarians.CoreMidiDeviceProvider"/>
 		</jar>
 	</target>


### PR DESCRIPTION
I was unable to use your Ant build because it assumed the repository was located in a particular location on the hard drive. By changing the build file to use relative paths, I can now run:

```
ant -f "Build/Project Builder.xml" MakeJar
```

and have it successfully build the Jar file for me:

```
Buildfile: /Users/james/git/CoreMidi4J-fork/CoreMIDI4J/Build/Project Builder.xml

MakeJar:
     [echo]  "Creating Jar File" 
   [delete] Deleting: /Users/james/git/CoreMidi4J-fork/CoreMIDI4J/Build/Release/CoreMIDI4J.jar
      [jar] Building jar: /Users/james/git/CoreMidi4J-fork/CoreMIDI4J/Build/Release/CoreMIDI4J.jar

BUILD SUCCESSFUL
Total time: 0 seconds
```

(I notice there are some other properties in there which still have absolute paths, but I suspect they are for configuring tools we do not need in this project, and they can probably be simply removed.)
