### PR TITLE
Selectively dispatch to main thread in CoreMidiClient::createClient

### DIFF
--- a/CoreMIDI4J/Native/CoreMidi4J/CoreMidiClient.cpp
+++ b/CoreMIDI4J/Native/CoreMidi4J/CoreMidiClient.cpp
@@ -139,10 +139,16 @@ JNIEXPORT jint JNICALL Java_uk_co_xfactorylibrarians_coremidi4j_CoreMidiClient_c
   //Ensure that the last call succeeded
   assert (result == JNI_OK);
 
-  // Setup the client on the GCD Event Queue - this will allow it to receive notifications
-  dispatch_sync(dispatch_get_main_queue(), ^{
+  // Setup the client on the main thread - this will allow it to receive notifications
+  if ( pthread_main_np() ) {
+    // Already on main thread
     status = MIDIClientCreate(cfClientName, &notifyCallback, g_callbackParameters, &client);
-  });
+  } else {
+    // Dispatch to main thread
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      status = MIDIClientCreate(cfClientName, &notifyCallback, g_callbackParameters, &client);
+    });
+  }
 
   // If status is non-zero then throw an exception
   if ( status != 0) {


### PR DESCRIPTION
Update CoreMidiClient::createClient to properly dispatch to main thread only
if not already executing on main thread.  pthread_main_np() is recommended on
the dispatch_get_main_queue() man page:

https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man3/dispatch_get_main_queue.3.html

"The result of dispatch_get_main_queue() may or may not equal the result of
dispatch_get_current_queue() when called on the main thread.  Comparing the two is not a
valid way to test whether code is executing on the main thread. Foundation/AppKit programs
should use [NSThread isMainThread]. POSIX programs may use pthread_main_np(3)."

This addresses a bug where JavaFX applications would crash when enumerating
MIDI devices because this method was invoked on the main thread, and the
synchronous call back to the main thread would have resulted in a deadlock.